### PR TITLE
feat(config): support editing update interval via OptionsFlow

### DIFF
--- a/custom_components/commax_iot/__init__.py
+++ b/custom_components/commax_iot/__init__.py
@@ -29,6 +29,16 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+def _get_update_interval(entry: ConfigEntry) -> int:
+    """설정/옵션에서 업데이트 주기를 가져온다."""
+    return int(
+        entry.options.get(
+            CONF_UPDATE_INTERVAL,
+            entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        )
+    )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """설정 항목에서 통합 구성요소 설정"""
     session = async_get_clientsession(hass)
@@ -44,10 +54,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = CommaxDataUpdateCoordinator(
         hass,
         auth_manager,
-        update_interval=entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        update_interval=_get_update_interval(entry),
     )
 
     await coordinator.async_config_entry_first_refresh()
+
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinator": coordinator,
@@ -57,6 +69,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """옵션 변경 시 통합을 재로드해 새 설정을 반영한다."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/commax_iot/config_flow.py
+++ b/custom_components/commax_iot/config_flow.py
@@ -28,11 +28,27 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+MIN_UPDATE_INTERVAL = 5
+MAX_UPDATE_INTERVAL = 3600
+
+
+def _validate_update_interval(value) -> int:
+    """업데이트 간격을 검증하고 정수로 반환."""
+    interval = int(value)
+    if interval < MIN_UPDATE_INTERVAL or interval > MAX_UPDATE_INTERVAL:
+        raise ValueError
+    return interval
+
 
 class CommaxIoTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Commax IoT 설정 흐름 핸들러"""
 
     VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        """옵션 플로우 핸들러 반환."""
+        return CommaxIoTOptionsFlow(config_entry)
 
     async def async_step_user(self, user_input=None):
         """사용자 입력 단계 처리"""
@@ -40,58 +56,66 @@ class CommaxIoTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                # 중복 확인
-                await self.async_set_unique_id(user_input[CONF_USER_ID])
-                self._abort_if_unique_id_configured()
-
-                # mobileUuid 자동 생성
-                mobile_uuid = str(uuid.uuid4()).upper()
-
-                # 인증 테스트
-                session = async_get_clientsession(self.hass)
-                auth_manager = CommaxAuthManager(
-                    mobile_uuid=mobile_uuid,
-                    user_id=user_input[CONF_USER_ID],
-                    user_pass=user_input[CONF_USER_PASS],
-                    session=session,
-                )
-
                 try:
-                    # 리소스 번호 자동 획득
-                    resource_no = await auth_manager.get_resource_no()
-                    if not resource_no:
-                        _LOGGER.warning("리소스 번호를 찾을 수 없습니다")
-                        errors["base"] = "no_resource"
-                    else:
-                        # 리소스 번호 설정 후 디바이스 목록 조회
-                        auth_manager.set_resource_no(resource_no)
-                        devices = await auth_manager.get_device_list()
-                        if not devices:
-                            _LOGGER.warning(
-                                "리소스에 등록된 디바이스가 없습니다 - resource_no: %s",
-                                resource_no,
-                            )
-                            errors["base"] = "no_devices"
-                        else:
-                            # 자동 생성/획득된 값들을 data에 추가
-                            entry_data = {
-                                **user_input,
-                                CONF_MOBILE_UUID: mobile_uuid,
-                                CONF_RESOURCE_NO: resource_no,
-                            }
-                            return self.async_create_entry(
-                                title=user_input.get(CONF_NAME, NAME),
-                                data=entry_data,
-                            )
-                except CommaxAuthenticationError:
-                    _LOGGER.warning(
-                        "Commax 인증에 실패했습니다 - 사용자 ID: %s",
-                        user_input[CONF_USER_ID],
+                    update_interval = _validate_update_interval(
+                        user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
                     )
-                    errors["base"] = "auth"
-                except CommaxApiError as err:
-                    _LOGGER.warning("Commax API 통신 중 오류가 발생했습니다: %s", err)
-                    errors["base"] = "cannot_connect"
+                except (TypeError, ValueError):
+                    errors["base"] = "invalid_interval"
+                else:
+                    # 중복 확인
+                    await self.async_set_unique_id(user_input[CONF_USER_ID])
+                    self._abort_if_unique_id_configured()
+
+                    # mobileUuid 자동 생성
+                    mobile_uuid = str(uuid.uuid4()).upper()
+
+                    # 인증 테스트
+                    session = async_get_clientsession(self.hass)
+                    auth_manager = CommaxAuthManager(
+                        mobile_uuid=mobile_uuid,
+                        user_id=user_input[CONF_USER_ID],
+                        user_pass=user_input[CONF_USER_PASS],
+                        session=session,
+                    )
+
+                    try:
+                        # 리소스 번호 자동 획득
+                        resource_no = await auth_manager.get_resource_no()
+                        if not resource_no:
+                            _LOGGER.warning("리소스 번호를 찾을 수 없습니다")
+                            errors["base"] = "no_resource"
+                        else:
+                            # 리소스 번호 설정 후 디바이스 목록 조회
+                            auth_manager.set_resource_no(resource_no)
+                            devices = await auth_manager.get_device_list()
+                            if not devices:
+                                _LOGGER.warning(
+                                    "리소스에 등록된 디바이스가 없습니다 - resource_no: %s",
+                                    resource_no,
+                                )
+                                errors["base"] = "no_devices"
+                            else:
+                                # 자동 생성/획득된 값들을 data에 추가
+                                entry_data = {
+                                    **user_input,
+                                    CONF_UPDATE_INTERVAL: update_interval,
+                                    CONF_MOBILE_UUID: mobile_uuid,
+                                    CONF_RESOURCE_NO: resource_no,
+                                }
+                                return self.async_create_entry(
+                                    title=user_input.get(CONF_NAME, NAME),
+                                    data=entry_data,
+                                )
+                    except CommaxAuthenticationError:
+                        _LOGGER.warning(
+                            "Commax 인증에 실패했습니다 - 사용자 ID: %s",
+                            user_input[CONF_USER_ID],
+                        )
+                        errors["base"] = "auth"
+                    except CommaxApiError as err:
+                        _LOGGER.warning("Commax API 통신 중 오류가 발생했습니다: %s", err)
+                        errors["base"] = "cannot_connect"
 
             except Exception:
                 _LOGGER.exception("설정 중 예상치 못한 오류 발생")
@@ -111,6 +135,44 @@ class CommaxIoTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_USER_ID): str,
                     vol.Required(CONF_USER_PASS): password_field,
                     vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): int,
+                }
+            ),
+            errors=errors,
+        )
+
+
+class CommaxIoTOptionsFlow(config_entries.OptionsFlow):
+    """Commax IoT 옵션 설정 흐름."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """옵션 초기 단계."""
+        errors = {}
+
+        if user_input is not None:
+            try:
+                update_interval = _validate_update_interval(
+                    user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+                )
+                return self.async_create_entry(
+                    title="",
+                    data={CONF_UPDATE_INTERVAL: update_interval},
+                )
+            except (TypeError, ValueError):
+                errors["base"] = "invalid_interval"
+
+        current_interval = self.config_entry.options.get(
+            CONF_UPDATE_INTERVAL,
+            self.config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_UPDATE_INTERVAL, default=current_interval): int,
                 }
             ),
             errors=errors,

--- a/custom_components/commax_iot/const.py
+++ b/custom_components/commax_iot/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "commax_iot"
 NAME = "COMMAX IoT"
-VERSION = "2026.2.16.3"
+VERSION = "2026.2.16.4"
 
 # API 엔드포인트
 AUTH_URL = "https://gauth-v2.commaxcloud.net/v2/oauth/user/authorize"

--- a/custom_components/commax_iot/manifest.json
+++ b/custom_components/commax_iot/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/yoonpooh/homeassistant-commax-iot/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "2026.2.16.3"
+  "version": "2026.2.16.4"
 }

--- a/custom_components/commax_iot/translations/en.json
+++ b/custom_components/commax_iot/translations/en.json
@@ -17,10 +17,25 @@
       "cannot_connect": "Unable to connect to the Commax service.",
       "no_resource": "No registered resource (wallpad) found.",
       "no_devices": "No devices were found for the resource.",
+      "invalid_interval": "Update interval must be between 5 and 3600 seconds.",
       "unknown": "Unexpected error occurred"
     },
     "abort": {
       "already_configured": "Device is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Commax IoT Options",
+        "description": "Configure polling update interval",
+        "data": {
+          "update_interval": "Update Interval (seconds)"
+        }
+      }
+    },
+    "error": {
+      "invalid_interval": "Update interval must be between 5 and 3600 seconds."
     }
   }
 }

--- a/custom_components/commax_iot/translations/ko.json
+++ b/custom_components/commax_iot/translations/ko.json
@@ -17,10 +17,25 @@
       "cannot_connect": "Commax 서비스에 연결할 수 없습니다.",
       "no_resource": "등록된 리소스(월패드)를 찾을 수 없습니다.",
       "no_devices": "리소스에 등록된 디바이스가 없습니다.",
+      "invalid_interval": "업데이트 간격은 5~3600초 사이여야 합니다.",
       "unknown": "예상치 못한 오류가 발생했습니다"
     },
     "abort": {
       "already_configured": "이미 설정된 디바이스입니다"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Commax IoT 옵션",
+        "description": "업데이트 간격을 설정하세요",
+        "data": {
+          "update_interval": "업데이트 간격 (초)"
+        }
+      }
+    },
+    "error": {
+      "invalid_interval": "업데이트 간격은 5~3600초 사이여야 합니다."
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `OptionsFlow` so `update_interval` can be edited after initial setup
- Apply option value with priority: `entry.options` -> `entry.data` -> default
- Reload integration on options change to apply polling interval immediately
- Add interval validation (5~3600 sec) and translation strings for config/options errors

## Validation
- `python3 -m compileall custom_components/commax_iot`

Closes #15